### PR TITLE
Archon "attack" should be negative.

### DIFF
--- a/engine/src/main/battlecode/common/RobotType.java
+++ b/engine/src/main/battlecode/common/RobotType.java
@@ -258,7 +258,7 @@ public enum RobotType {
         if (!this.isBuilding() || level == 1) {
             return this.damage;
         } else if (this == RobotType.ARCHON) {
-            return level == 2 ? 3 : 4;
+            return level == 2 ? -3 : -4;
         } else if (this == RobotType.LABORATORY) {
             return 0;
         } else {


### PR DESCRIPTION
The "attack" values of an upgraded Archon should stay negative since it is healing.  The base value is negative, but the overriding values when the Archon is upgraded are positive.

RobotType.java:

```
    public int getDamage(int level) {
        if (!this.isBuilding() || level == 1) {
            return this.damage;
        } else if (this == RobotType.ARCHON) {
            return level == 2 ? 3 : 4;
        } else if (this == RobotType.LABORATORY) {
            return 0;
        } else {
            return level == 2 ? 6 : 7;
        }
    }
```
It should be `return level == 2 ? -3 : -4;`