### PR TITLE
Alphabetically sort bots in team selectors in client runner

### DIFF
--- a/client/visualizer/src/sidebar/matchrunner.ts
+++ b/client/visualizer/src/sidebar/matchrunner.ts
@@ -270,7 +270,7 @@ export default class MatchRunner {
     }
     // Found the packages, make the team selectors
     if (packages) {
-      for (let player of packages) {
+      for (let player of packages.sort((a, b) => a.localeCompare(b))) {
         // Add the player to team A
         const optionA = document.createElement("option");
         optionA.value = player;


### PR DESCRIPTION
Updated the team selectors in the client runner so that bots are shown in alphabetical order. This makes the order consistent between client restarts, and makes it easier to find the latest versioned bot when using version numbers in bot names (i.e. camel_case_v01, camel_case_v02, etc.).

![](https://i.imgur.com/nbt7rSw.png)