### PR TITLE
Server should not begin match with invalid map size

### DIFF
--- a/engine/src/main/battlecode/server/Server.java
+++ b/engine/src/main/battlecode/server/Server.java
@@ -217,6 +217,20 @@ public strictfp class Server implements Runnable {
 
         // Create the game world!
         currentWorld = new GameWorld(loadedMap, prov, gameMaker.getMatchMaker());
+        
+        // Check map dimensions
+        if (currentWorld.getGameMap().getWidth() > GameConstants.MAP_MAX_WIDTH) {
+            throw new RuntimeException("MAP WIDTH EXCEEDS GameConstants.MAP_MAX_WIDTH");
+        }
+        if (currentWorld.getGameMap().getWidth() < GameConstants.MAP_MIN_WIDTH) {
+            throw new RuntimeException("MAP WIDTH BENEATH GameConstants.MAP_MIN_WIDTH");
+        }
+        if (currentWorld.getGameMap().getHeight() > GameConstants.MAP_MAX_HEIGHT) {
+            throw new RuntimeException("MAP HEIGHT EXCEEDS GameConstants.MAP_MAX_HEIGHT");
+        }
+        if (currentWorld.getGameMap().getHeight() < GameConstants.MAP_MIN_HEIGHT) {
+            throw new RuntimeException("MAP HEIGHT BENEATH GameConstants.MAP_MIN_HEIGHT");
+        }
 
         // Get started
         if (interactive) {


### PR DESCRIPTION
Invalid map appeared during sprint 1. I hope I did this correctly, let me know if I didn't I am happy to iterate. Cheers.

These may need checks too in the future.
** The minimum number of starting Archons per team. */
    public static final int MIN_STARTING_ARCHONS = 1;

    /** The maximum number of starting Archons per team. */
    public static final int MAX_STARTING_ARCHONS = 4;

    /** The minimum amount of rubble per square. */
    public static final int MIN_RUBBLE = 0;

    /** The maximum amount of rubble per square. */
    public static final int MAX_RUBBLE = 100;