### PR TITLE
Make release public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   RELEASE_ARTIFACT_ID: battlecode22
 
   # IS_PUBLIC is whether to release deployments publicly. Set to exactly the text "YES" to do so.
-  IS_PUBLIC: NO
+  IS_PUBLIC: YES
 
 jobs:
   release:

--- a/client/visualizer/src/config.ts
+++ b/client/visualizer/src/config.ts
@@ -146,7 +146,7 @@ export enum Mode {
  */
 export function defaults(supplied?: any): Config {
   let conf: Config = {
-    gameVersion: "2022.2.2.3", //TODO: Change this on each release!
+    gameVersion: "2022.2.2.4", //TODO: Change this on each release!
     fullscreen: false,
     width: 600,
     height: 600,

--- a/engine/src/main/battlecode/common/GameConstants.java
+++ b/engine/src/main/battlecode/common/GameConstants.java
@@ -9,7 +9,7 @@ public class GameConstants {
     /**
      * The current spec version the server compiles with.
      */
-    public static final String SPEC_VERSION = "2022.2.2.3";
+    public static final String SPEC_VERSION = "2022.2.2.4";
 
     // *********************************
     // ****** MAP CONSTANTS ************

--- a/specs/specs.md.html
+++ b/specs/specs.md.html
@@ -17,7 +17,7 @@
 
 # Formal specification
 
-*This is the formal specification of the Battlecode 2022 game.* Current version: *2022.2.2.3*
+*This is the formal specification of the Battlecode 2022 game.* Current version: *2022.2.2.4*
 
 **Welcome to Battlecode 2022: Mutation.**
 


### PR DESCRIPTION
also bumps vernums

TODO: in release, tag w simply `2.2.4`, which will follow modern Saturn system.